### PR TITLE
Location aware errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,31 @@ module.exports = function (app, opts, done) {
   //
   // Generally you want your error handling last.
   //
-  app.use(require('slay-error')(app));
+  app.use(require('slay-error')(app, { disableLog: false }));
 };
 ```
+In your application, when you pass an error to the `next(error)`
+callback of a request handler, this middleware will handle the reporting
+and response for that error in your application.
+```
+module.exports = function handler(req, res, next) {
+  // if error
+  next(new Error('let the middleware handle this'));
+};
+```
+
+If the error that you pass to this middleware has a `location` property,
+`res.location(error.location)` will be called for you.
+
+If you don't want the error logged, you can use the option `disableLog:
+true` or set the `log` property of the error to `false`.
+
+You can also control the log level of the error using the level
+property. So, if `level: 'info'` only `app.log.info` will be invoked
+with the log message and metadata.
+
+### Hint
+In your application you can use a tool like [errs](https://www.npmjs.com/package/errs) that
+will allow you to define the structure of errors, either with
+pre-defined/registered errors or by passing all of the properties of the
+error to `errs.create`

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "middleware.js",
   "scripts": {
     "lint": "godaddy-js-style-lint *.js",
-    "pretest": "npm run lint",
-    "test": "istanbul cover ./node_modules/.bin/_mocha test/*.test.js"
+    "test": "npm run lint"
   },
   "author": "Charlie Robbins <crobbins@godaddy.com>",
   "repository": {


### PR DESCRIPTION
Error contents should contain all properties of the error.
When errors that use a redirect have the location specified, we should
pass that value to the response. When the error specifies the log level,
we should log at that level.